### PR TITLE
Use 0.0.0/composer-include-files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,6 @@
     }
   ],
   "require": {
-    "funkjedi/composer-include-files": "^1.0"
+    "0.0.0/composer-include-files": "^1.0"
   }
 }


### PR DESCRIPTION
0.0.0/composer-include-files is currently the only known way to include a file first and foremost before any others in Composer, that also works for third-party installs.

它是目前唯一已知的方法，首先将文件包含在Composer中的任何其他文件之前，这也适用于第三方安装。